### PR TITLE
Fix software rasterizer

### DIFF
--- a/src/graphics/Software.cpp
+++ b/src/graphics/Software.cpp
@@ -369,8 +369,13 @@ inline ZunVec3 Software::ProjectToNDC(ZunVec3 vertex, ZunMatrix mv, ZunMatrix p,
     viewZ = clip.z;
     clip = p * clip;
     ZunVec3 ndc = {clip.x, clip.y, clip.z};
-    if (clip.w != 0)
+
+    //this is probably incorrect but at least it prevents background on stage 2 from breaking without adding complexity
+    if (clip.w <= 0)
     {
+        W = 1.0f;
+        return ndc;
+    } else {
         ndc /= clip.w;
         W = 1.0f / clip.w;
     }
@@ -446,12 +451,6 @@ void Software::Draw(PrimitiveType type, i32 start, i32 count)
                                   viewZ1, invw1);
         ZunVec3 v2 = ProjectToNDC(*(ZunVec3 *)((u8 *)vertexData + vertexStride * (index + 2)), modelview, projection,
                                   viewZ2, invw2);
-
-        if(invw0 < 0 || invw1 < 0 || invw2 < 0)
-        {
-            index += increment;
-            continue;
-        }
 
         ZunVec2 tc0, tc1, tc2;
         Diffuse diffuse0, diffuse1, diffuse2;

--- a/src/graphics/Software.cpp
+++ b/src/graphics/Software.cpp
@@ -370,12 +370,14 @@ inline ZunVec3 Software::ProjectToNDC(ZunVec3 vertex, ZunMatrix mv, ZunMatrix p,
     clip = p * clip;
     ZunVec3 ndc = {clip.x, clip.y, clip.z};
 
-    //this is probably incorrect but at least it prevents background on stage 2 from breaking without adding complexity
+    // this is probably incorrect but at least it prevents background on stage 2 from breaking without adding complexity
     if (clip.w <= 0)
     {
         W = 1.0f;
         return ndc;
-    } else {
+    }
+    else
+    {
         ndc /= clip.w;
         W = 1.0f / clip.w;
     }
@@ -573,7 +575,8 @@ void Software::Draw(PrimitiveType type, i32 start, i32 count)
                     f32 depth;
                     if (useDepthTest)
                     {
-                        depth = ZUN_MAX(ZUN_MIN(((ndcZ * clipW) * 0.5f + 0.5f) * depthDif + depthNear, depthFar), depthNear);
+                        depth = ZUN_MAX(ZUN_MIN(((ndcZ * clipW) * 0.5f + 0.5f) * depthDif + depthNear, depthFar),
+                                        depthNear);
                         if (depthFunc == DEPTH_FUNC_LEQUAL && depth > depthBuffer[pixelCoord])
                         {
                             continue;

--- a/src/graphics/Software.cpp
+++ b/src/graphics/Software.cpp
@@ -447,6 +447,12 @@ void Software::Draw(PrimitiveType type, i32 start, i32 count)
         ZunVec3 v2 = ProjectToNDC(*(ZunVec3 *)((u8 *)vertexData + vertexStride * (index + 2)), modelview, projection,
                                   viewZ2, invw2);
 
+        if(invw0 < 0 || invw1 < 0 || invw2 < 0)
+        {
+            index += increment;
+            continue;
+        }
+
         ZunVec2 tc0, tc1, tc2;
         Diffuse diffuse0, diffuse1, diffuse2;
         u32 *texels;
@@ -568,7 +574,7 @@ void Software::Draw(PrimitiveType type, i32 start, i32 count)
                     f32 depth;
                     if (useDepthTest)
                     {
-                        depth = ((ndcZ * clipW) * 0.5f + 0.5f) * depthDif + depthNear;
+                        depth = ZUN_MAX(ZUN_MIN(((ndcZ * clipW) * 0.5f + 0.5f) * depthDif + depthNear, depthFar), depthNear);
                         if (depthFunc == DEPTH_FUNC_LEQUAL && depth > depthBuffer[pixelCoord])
                         {
                             continue;


### PR DESCRIPTION
This fixes two problems the software rasterizer had on stage 2:
- because depth was not properly capped, some enemies/background tiles would write values past the depth near / far bounds preventing other objects that would be on top from appearing
-  The projection calculation would break once the front quads from the background got too far behind the camera (the two quads close to the camera would simply disappear). The calculation is probably still incorrect but at least this doesnt break anything else and i dont want to bother to add near plane clipping or anything like that because i stared at the code for about two weeks by this point